### PR TITLE
fix: fix credential and fernet keys copy method to avoid permission denied

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,7 @@ openio_keystone_system_user_name: keystone
 openio_keystone_system_group_name: keystone
 openio_keystone_config_dir: /etc/keystone
 openio_keystone_config_default_log_dir: /var/log/keystone
+openio_keystone_tmp_keys_dir: /tmp
 
 # uWSGI
 openio_keystone_wsgi_threads: 1

--- a/tasks/keystone_credentials.yml
+++ b/tasks/keystone_credentials.yml
@@ -2,11 +2,29 @@
 - include: keystone_credentials_keys_create.yml
   when: inventory_hostname == groups[openio_keystone_inventory_group][0]
 
-- name: Copying credentials key repository
+- name: Fetch credentials tokens locally
+  synchronize:
+    mode: pull
+    src: "{{ openio_keystone_credentials_tokens_key_repository }}"
+    dest: "{{ openio_keystone_tmp_keys_dir }}/credential-keys"
+    archive: yes
+    delete: yes
+  when: inventory_hostname == groups[openio_keystone_inventory_group][0]
+
+- name: Copying credentials keys to all keystone hosts
   synchronize:
     mode: push
-    src: "{{ openio_keystone_credentials_tokens_key_repository }}"
-    dest: "{{ openio_keystone_credentials_tokens_key_repository }}"
+    src: "{{ openio_keystone_tmp_keys_dir }}/credential-keys"
+    dest: "{{ openio_keystone_credentials_tokens_key_repository }}/.."
+    archive: yes
+    delete: yes
   when: inventory_hostname != groups[openio_keystone_inventory_group][0]
-  delegate_to: "{{ groups[openio_keystone_inventory_group][0] }}"
+
+- name: Reset credentials keys ownership
+  file:
+    path: "{{ openio_keystone_credentials_tokens_key_repository }}"
+    owner: root
+    group: root
+    state: directory
+    recurse: yes
 ...

--- a/tasks/keystone_fernet.yml
+++ b/tasks/keystone_fernet.yml
@@ -2,11 +2,29 @@
 - include: keystone_fernet_keys_create.yml
   when: inventory_hostname == groups[openio_keystone_inventory_group][0]
 
-- name: Copying fernet key repository
+- name: fetch fernet tokens locally
+  synchronize:
+    mode: pull
+    src: "{{ openio_keystone_fernet_tokens_key_repository }}"
+    dest: "{{ openio_keystone_tmp_keys_dir }}/fernet-keys"
+    archive: yes
+    delete: yes
+  when: inventory_hostname == groups[openio_keystone_inventory_group][0]
+
+- name: Copying fernet keys to all keystone hosts
   synchronize:
     mode: push
-    src: "{{ openio_keystone_fernet_tokens_key_repository }}"
-    dest: "{{ openio_keystone_fernet_tokens_key_repository }}"
+    src: "{{ openio_keystone_tmp_keys_dir }}/fernet-keys"
+    dest: "{{ openio_keystone_fernet_tokens_key_repository }}/.."
+    archive: yes
+    delete: yes
   when: inventory_hostname != groups[openio_keystone_inventory_group][0]
-  delegate_to: "{{ groups[openio_keystone_inventory_group][0] }}"
+
+- name: Reset fernet keys ownership
+  file:
+    path: "{{ openio_keystone_fernet_tokens_key_repository }}"
+    owner: root
+    group: root
+    state: directory
+    recurse: yes
 ...


### PR DESCRIPTION
When you're not allowed to directly connect with root user, a
synchronize between nodes return permission denied. This is because of
/etc/keystone default permissions. To workaround that issue, I grab
locally the keys and then send them to others hosts.