### PR TITLE
Add a task of role creation

### DIFF
--- a/tasks/postinstall.yml
+++ b/tasks/postinstall.yml
@@ -47,6 +47,21 @@
   retries: 5
   delay: 10
 
+- name: Create roles
+  command: "openstack --os-cloud {{ openio_keystone_cloudname }} \
+    role create {{ item.1.role }}"
+  with_subelements:
+    - "{{ openio_keystone_projects }}"
+    - roles
+  run_once: "{{ not openio_keystone_bootstrap_all_nodes }}"
+  register: create_role
+  changed_when: create_role.rc == 0
+  failed_when:
+    - create_role.rc != 0
+    - not 'Duplicate entry found with name' in create_role.stderr
+  until: create_role is success
+  retries: 5
+  delay: 10
 
 - name: Add roles to projects
   os_user_role:

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -9,6 +9,7 @@ keystone_packages:
   - python-cffi
   - python-pip
   - rsync
+  - python-openstackclient
 
 #openio_keystone_uwsgi_config_dir: /etc/uwsgi
 openio_keystone_uwsgi_bin: /usr/bin/uwsgi

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -7,6 +7,7 @@ keystone_packages:
   - uwsgi-plugin-python
   - python2-shade
   - rsync
+  - python-openstackclient
 
 openio_keystone_uwsgi_bin: /sbin/uwsgi
 ...


### PR DESCRIPTION
Keystone Queens doesn't autocreate role at assignment (or I did not find how to set it in keystone.conf)
Nevertheless, the creation of a role before assignment seems to me legit.

In addition, openstackclient is no longer installed in Queens (at least on Bionic Beaver)