### PR TITLE
BUGFIX/MEDIUM(keystone): Disable package provided keystone.conf on Ubuntu

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -17,6 +17,11 @@
   retries: 5
   delay: 2
 
+- name: Remove default keystone service
+  file:
+    path: /etc/apache2/sites-enabled/keystone.conf
+    state: absent
+
 - name: Upgrade python-shade
   pip:
     name: shade


### PR DESCRIPTION
 ##### SUMMARY

On Ubuntu, keystone package deployes an enabled keystone.conf file for
apache, that listens on port 5000. This causes a conflict with the
actual service when the node restarts. The fix disables the
package-provided keystone.conf from apache2.

Fixes: OB-328

 ##### ISSUE TYPE
- Bugfix Pull Request

 ##### IMPACT
N/A