### PR TITLE
BUGFIX(keystone): Change OS_AUTH_URL port for admin credential clouds.yaml

### DIFF
--- a/templates/clouds.yaml.j2
+++ b/templates/clouds.yaml.j2
@@ -6,7 +6,7 @@ clouds:
       username: admin
       project_name: admin
       password: {{ openio_keystone_services_to_bootstrap | selectattr('name', 'match', '^keystone$') | map(attribute='password') | list | first }}
-      auth_url: {{ openio_keystone_services_to_bootstrap | selectattr('name', 'match', '^keystone$') | map(attribute='publicurl') | list | first }}
+      auth_url: {{ openio_keystone_services_to_bootstrap | selectattr('name', 'match', '^keystone$') | map(attribute='adminurl') | list | first }}
       user_domain_name: Default
       project_domain_name: Default
     identity_api_version: 3


### PR DESCRIPTION

 ##### SUMMARY
In the file /etc/openstack/clouds.yaml, the port of the OS_AUTH_URL was
pointing to the Keystone public service (5000). Not all capabilities are
available from this port, it is recommended to use port 35357 for
admin purpose.

 ##### IMPACT
N/A