### PR TITLE
BUGFIX/MAJOR(keystone): Add maintenance mode

### DIFF
--- a/tasks/uwsgi.yml
+++ b/tasks/uwsgi.yml
@@ -25,5 +25,7 @@
   shell: |
     gridinit_cmd reload
     gridinit_cmd restart  {{openio_keystone_namespace}}-keystone-{{openio_keystone_serviceid}}
-  when: _keystone_conf.changed
+  when:
+    - _keystone_conf.changed
+    - not openio_keystone_provision_only
 ...


### PR DESCRIPTION

 ##### SUMMARY

Lack of maintenance mode in uwsgi delivery --> restart service and reload gridinit even if openio_maintenance_mode is set to true

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION