### PR TITLE
BUGFIX/MINOR(keystone): Remove useless path in Swift admin URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ openio_keystone_services:
     description: OpenIO SDS swift proxy
     endpoint:
       - interface: admin
-        url: "http://foo.com:6007/v1/AUTH_%(tenant_id)s"
+        url: "http://foo.com:6007"
       - interface: internal
         url: "http://foo.com:6007/v1/AUTH_%(tenant_id)s"
       - interface: public

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -95,7 +95,7 @@ openio_keystone_services:
     description: OpenIO SDS swift proxy
     endpoint:
       - interface: admin
-        url: "http://{{ openio_keystone_bind_address }}:6007/v1/AUTH_%(tenant_id)s"
+        url: "http://{{ openio_keystone_bind_address }}:6007"
       - interface: internal
         url: "http://{{ openio_keystone_bind_address }}:6007/v1/AUTH_%(tenant_id)s"
       - interface: public


### PR DESCRIPTION
 ##### SUMMARY
Remove the useless path in Swift admin URL.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
https://wiki.openstack.org/wiki/Swift/DevstackSetupForKeystoneV3
https://docs.openstack.org/swift/pike/overview_auth.html