### PR TITLE
CHANGE(keystone): Ensure service is started or restarted at the end o…

### DIFF
--- a/docker-tests/test.yml
+++ b/docker-tests/test.yml
@@ -16,11 +16,8 @@
   roles:
     - role: users
     - role: repo
-      openio_repository_openstack_release: 'queens'
       openio_repository_no_log: false
-      openio_repository_products:
-        sds:
-          release: "18.10"
+      openio_repository_mirror_host: mirror2.openio.io
     - role: gridinit
       openio_gridinit_per_ns: true
       openio_gridinit_namespace: TRAVIS

--- a/docker-tests/test_mysql.yml
+++ b/docker-tests/test_mysql.yml
@@ -37,11 +37,8 @@
 
     - role: users
     - role: repo
-      openio_repository_openstack_release: 'queens'
       openio_repository_no_log: false
-      openio_repository_products:
-        sds:
-          release: "18.10"
+      openio_repository_mirror_host: mirror2.openio.io
     - role: gridinit
       openio_gridinit_per_ns: true
       openio_gridinit_namespace: TRAVIS

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -74,11 +74,24 @@
 - name: restart keystone
   shell: |
     gridinit_cmd reload
-    gridinit_cmd restart  {{openio_keystone_namespace}}-keystone-{{openio_keystone_serviceid}}.0
-    gridinit_cmd restart  {{openio_keystone_namespace}}-keystone-{{openio_keystone_serviceid}}.1
+    gridinit_cmd restart  {{ openio_keystone_namespace }}-{{ openio_keystone_servicename }}.0
+    gridinit_cmd restart  {{ openio_keystone_namespace }}-{{ openio_keystone_servicename }}.1
+  register: _restart_keystone
   when:
-    - _uwsgi_conf.changed or _gridinit_conf.changed
+    - _uwsgi_conf is changed or _gridinit_conf is changed
     - not openio_keystone_provision_only
+
+- block:
+    - name: "Ensure keystone is started"
+      command: "gridinit_cmd start {{ openio_keystone_namespace }}-{{ openio_keystone_servicename }}.0 \
+        {{ openio_keystone_namespace }}-{{ openio_keystone_servicename }}.1"
+      register: _start_keystone
+      changed_when: '"Success" in _start_keystone.stdout'
+      when:
+        - not openio_keystone_provision_only
+        - _restart_keystone is skipped
+      tags: configure
+  when: openio_bootstrap | d(false)
 
 - import_tasks: bootstrap.yml
   when:


### PR DESCRIPTION
…f role

 ##### SUMMARY
Until 18.10, a voluntarily stopped service was not revived by a reproviosionning.

In 19.04, the `maintenance` mode becomes the default mode.

To avoid having to force (ie. deletion of conf files) the restart of a service delivered first, by error, in maintenance mode: We have to make sure that service is started and it works well at the end of the role.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION