### PR TITLE
BUGFIX/MINOR(keystone): Fix the use of tags `install` and `configure`

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -3,6 +3,7 @@
   apt:
     update_cache: true
   changed_when: false
+  tags: install
 
 - name: Install packages
   package:
@@ -16,11 +17,13 @@
   until: install_packages is success
   retries: 5
   delay: 2
+  tags: install
 
 - name: Remove default keystone service
   file:
     path: /etc/apache2/sites-enabled/keystone.conf
     state: absent
+  tags: install
 
 - name: Upgrade python-shade
   pip:
@@ -32,4 +35,5 @@
   retries: 5
   delay: 2
   ignore_errors: "{{ ansible_check_mode }}"
+  tags: install
 ...

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -11,4 +11,5 @@
   until: install_packages is success
   retries: 5
   delay: 2
+  tags: install
 ...

--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -11,6 +11,7 @@
   until: _wait_check is success
   retries: 12
   delay: 5
+  tags: configure
 
 - name: Bootstrap keystone admin and endpoint
   command: "{{ openio_keystone_bindir }}/keystone-manage bootstrap \
@@ -28,6 +29,8 @@
   until: add_service is success
   retries: 5
   delay: 10
-  tags: skip_ansible_lint
+  tags:
+    - skip_ansible_lint
+    - configure
   no_log: "{{ openio_keystone_no_log }}"
 ...

--- a/tasks/credentials.yml
+++ b/tasks/credentials.yml
@@ -1,6 +1,7 @@
 ---
 - import_tasks: credentials_create.yml
   when: inventory_hostname == groups[openio_keystone_nodes_group][0]
+  tags: configure
 
 - name: Fetch credentials tokens locally
   synchronize:
@@ -13,6 +14,7 @@
   when: inventory_hostname == groups[openio_keystone_nodes_group][0]
   changed_when: false
   ignore_errors: "{{ ansible_check_mode }}"
+  tags: configure
 
 - name: Copying credentials keys to all keystone hosts
   synchronize:
@@ -23,6 +25,7 @@
     delete: "yes"
     use_ssh_args: "yes"
   when: inventory_hostname != groups[openio_keystone_nodes_group][0]
+  tags: configure
 
 - name: Reset credentials keys ownership
   file:
@@ -31,4 +34,5 @@
     group: "{{ openio_keystone_system_group_name }}"
     state: directory
     recurse: "yes"
+  tags: configure
 ...

--- a/tasks/credentials_create.yml
+++ b/tasks/credentials_create.yml
@@ -17,6 +17,7 @@
   stat:
     path: "{{ openio_keystone_credentials_tokens_key_repository }}/0"
   register: _credential_keys
+  tags: configure
 
 - name: Check for credential keys on all Keystone containers
   find:
@@ -27,6 +28,7 @@
   register: credential_key_list
   delegate_to: "{{ item }}"
   with_items: "{{ groups[openio_keystone_nodes_group] }}"
+  tags: configure
 
 
 - name: Aggregate the collected file lists
@@ -42,6 +44,7 @@
       {% endfor -%}
       {{ _var }}
   when: not credential_key_list is skipped
+  tags: configure
 
 - name: Collect the existing keys from containers
   slurp:
@@ -50,6 +53,7 @@
   with_items: "{{ existing_credential_keys }}"
   register: collected_existing_credential_keys
   when: existing_credential_keys is defined
+  tags: configure
 
 - name: Ensure the target directory exists on the master Keystone container
   file:
@@ -59,6 +63,7 @@
     group: "{{ openio_keystone_system_group_name }}"
     mode: "0700"
   when: not collected_existing_credential_keys is skipped
+  tags: configure
 
 - name: Drop the existing credential keys in the master Keystone container
   copy:
@@ -70,6 +75,7 @@
   when: not collected_existing_credential_keys is skipped
   register: drop_existing_credential_keys
   with_indexed_items: "{{ collected_existing_credential_keys.results | map(attribute='content') | list | unique }}"
+  tags: configure
 
 - name: Create credential keys for Keystone
   command: >
@@ -80,6 +86,7 @@
   when:
     - not _credential_keys.stat.exists
     - not drop_existing_credential_keys is changed
+  tags: configure
 
 - name: Ensure newest key is used for credential in Keystone
   command: >
@@ -88,6 +95,7 @@
                                        --keystone-group "{{ openio_keystone_system_group_name }}"
   when: create_credential_keys is skipped
   changed_when: false
+  tags: configure
 
 - name: Rotate credential keys for Keystone
   command: >
@@ -96,4 +104,5 @@
                                        --keystone-group "{{ openio_keystone_system_group_name }}"
   when: create_credential_keys is skipped
   changed_when: false
+  tags: configure
 ...

--- a/tasks/db_setup.yml
+++ b/tasks/db_setup.yml
@@ -7,6 +7,7 @@
     mode: 0755
     state: directory
   when: openio_keystone_database_engine == 'sqlite'
+  tags: configure
 
 - name: Create SQLite databases
   file:
@@ -17,6 +18,7 @@
     state: touch
   changed_when: false
   when: openio_keystone_database_engine == 'sqlite'
+  tags: configure
 
 - name: Check current state of Keystone DB
   command: "{{ openio_keystone_bindir }}/keystone-manage db_sync --check"
@@ -24,6 +26,7 @@
   failed_when: "_db_sync_check.rc | int == 1"
   changed_when: false
   run_once: "{{ not openio_keystone_bootstrap_all_nodes }}"
+  tags: configure
 
 - name: "Perform a Keystone DB sync expand"
   command: "{{ openio_keystone_bindir }}/keystone-manage db_sync --expand"
@@ -31,6 +34,7 @@
   when:
     - _db_sync_check.rc | int == 2
   ignore_errors: "{{ ansible_check_mode }}"
+  tags: configure
 
 - name: Perform a Keystone DB sync migrate
   command: "{{ openio_keystone_bindir }}/keystone-manage db_sync --migrate"
@@ -38,6 +42,7 @@
   when:
     - _db_sync_check.rc | int in [2, 3]
   ignore_errors: "{{ ansible_check_mode }}"
+  tags: configure
 
 - name: Perform a Keystone DB sync contract
   command: "{{ openio_keystone_bindir }}/keystone-manage db_sync --contract"
@@ -45,4 +50,5 @@
   when:
     - _db_sync_check.rc | int in [2, 3, 4]
   ignore_errors: "{{ ansible_check_mode }}"
+  tags: configure
 ...

--- a/tasks/fernet.yml
+++ b/tasks/fernet.yml
@@ -1,6 +1,7 @@
 ---
 - import_tasks: fernet_keys_create.yml
   when: inventory_hostname == groups[openio_keystone_nodes_group][0]
+  tags: configure
 
 # Synchronize Fernet on all nodes
 - name: fetch fernet tokens locally
@@ -14,6 +15,7 @@
   when: inventory_hostname == groups[openio_keystone_nodes_group][0]
   changed_when: false
   ignore_errors: "{{ ansible_check_mode }}"
+  tags: configure
 
 - name: Copying fernet keys to all keystone hosts
   synchronize:
@@ -24,6 +26,7 @@
     delete: "yes"
     use_ssh_args: "yes"
   when: inventory_hostname != groups[openio_keystone_nodes_group][0]
+  tags: configure
 
 - name: Reset fernet keys ownership
   file:
@@ -32,4 +35,5 @@
     group: "{{ openio_keystone_system_group_name }}"
     state: directory
     recurse: "yes"
+  tags: configure
 ...

--- a/tasks/fernet_keys_create.yml
+++ b/tasks/fernet_keys_create.yml
@@ -17,12 +17,14 @@
   stat:
     path: "{{ openio_keystone_fernet_tokens_key_repository }}/0"
   register: _fernet_keys
+  tags: configure
 
 - name: Create fernet keys for Keystone
   command: >
     {{ openio_keystone_bindir }}/keystone-manage fernet_setup
                                        --keystone-user "{{ openio_keystone_system_user_name }}"
                                        --keystone-group "{{ openio_keystone_system_group_name }}"
+  tags: configure
   when:
     - not _fernet_keys.stat.exists
 
@@ -31,6 +33,7 @@
     {{ openio_keystone_bindir }}/keystone-manage fernet_rotate
                                        --keystone-user "{{ openio_keystone_system_user_name }}"
                                        --keystone-group "{{ openio_keystone_system_group_name }}"
+  tags: configure
   when:
     - not _fernet_keys.stat.exists
   changed_when: false

--- a/tasks/identities_create.yml
+++ b/tasks/identities_create.yml
@@ -15,7 +15,7 @@
   retries: 5
   delay: 10
   no_log: "{{ openio_keystone_no_log }}"
-
+  tags: configure
 
 - name: Projects creation
   os_project:
@@ -31,6 +31,7 @@
   retries: 5
   delay: 10
   ignore_errors: "{{ ansible_check_mode }}"
+  tags: configure
 
 - name: Create roles
   command: "openstack --os-cloud {{ openio_keystone_cloudname }} \
@@ -47,6 +48,7 @@
   until: create_role is success
   retries: 5
   delay: 10
+  tags: configure
 
 - name: Add roles to projects
   os_user_role:
@@ -63,6 +65,7 @@
   retries: 5
   delay: 10
   ignore_errors: "{{ ansible_check_mode }}"
+  tags: configure
 
 - name: Declare a service
   os_keystone_service:
@@ -78,6 +81,7 @@
   retries: 5
   delay: 10
   ignore_errors: "{{ ansible_check_mode }}"
+  tags: configure
 
 #- name: Add endpoint to service
 #  os_keystone_endpoint:
@@ -90,6 +94,7 @@
 #    - "{{ openio_keystone_services }}"
 #    - endpoint
 #  run_once: "{{ not openio_keystone_bootstrap_all_nodes }}"
+#  tags: configure
 
 - name: Add endpoint to service
   command: "openstack --os-cloud {{ openio_keystone_cloudname }} endpoint create \
@@ -105,4 +110,5 @@
   retries: 5
   delay: 10
   ignore_errors: "{{ ansible_check_mode }}"
+  tags: configure
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,9 @@
   with_first_found:
     - "{{ ansible_distribution }}.yml"
     - "{{ ansible_os_family }}.yml"
-  tags: install
+  tags:
+    - install
+    - configure
 
 - name: "Include {{ ansible_distribution }} tasks"
   include_tasks: "{{ item }}"
@@ -24,7 +26,7 @@
   with_items:
     - path: "/etc/gridinit.d/{{ openio_keystone_namespace }}"
     - path: "{{ openio_keystone_sysconfig_dir }}/keystone-{{ openio_keystone_serviceid }}"
-  tags: install
+  tags: configure
 
 - name: 'Install configuration files keystone-paste.ini'
   copy:
@@ -49,10 +51,12 @@
   when: not openio_keystone_provision_only
 
 - import_tasks: fernet.yml
+  tags: configure
   when:
     - "'fernet' in openio_keystone_token_provider"
 
 - import_tasks: credentials.yml
+  tags: configure
 
 - name: Generate configuration files (uwsgi)
   template:
@@ -61,6 +65,7 @@
     mode: "0644"
   with_items: "{{ openio_keystone_wsgi_program_names }}"
   register: _uwsgi_conf
+  tags: configure
 
 - name: Generate configuration files (gridinit)
   template:
@@ -70,6 +75,7 @@
     mode: "0644"
   with_indexed_items: "{{ openio_keystone_wsgi_program_names }}"
   register: _gridinit_conf
+  tags: configure
 
 - name: restart keystone
   shell: |
@@ -77,6 +83,7 @@
     gridinit_cmd restart  {{ openio_keystone_namespace }}-{{ openio_keystone_servicename }}.0
     gridinit_cmd restart  {{ openio_keystone_namespace }}-{{ openio_keystone_servicename }}.1
   register: _restart_keystone
+  tags: configure
   when:
     - _uwsgi_conf is changed or _gridinit_conf is changed
     - not openio_keystone_provision_only

--- a/tasks/postinstall.yml
+++ b/tasks/postinstall.yml
@@ -5,6 +5,7 @@
     state: directory
     owner: root
     group: root
+  tags: configure
 
 - name: Adding clouds.yaml for os-client-config for further actions
   template:
@@ -14,6 +15,7 @@
     group: root
     mode: 0400
   no_log: "{{ openio_keystone_no_log }}"
+  tags: configure
 
 - name: 'Install configuration logrotate files'
   template:
@@ -22,4 +24,5 @@
     owner: root
     group: root
     mode: '0644'
+  tags: configure
 ...

--- a/tasks/uwsgi.yml
+++ b/tasks/uwsgi.yml
@@ -20,6 +20,7 @@
     mode: "0744"
   with_items: "{{ openio_keystone_wsgi_program_names }}"
   register: _keystone_conf
+  tags: configure
 
 - name: restart keystone
   shell: |
@@ -28,4 +29,5 @@
   when:
     - _keystone_conf.changed
     - not openio_keystone_provision_only
+  tags: configure
 ...


### PR DESCRIPTION
 ##### SUMMARY

It can be useful to prepare images to run only the `install` tag and then only the` configure` tag

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION