### PR TITLE
BUGFIX/MINOR(keystone): Fix duplicates memcached entries

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,7 +43,7 @@ openio_keystone_config_cache_debug_cache_backend: ""
 openio_keystone_config_cache_memcache_servers: "{% if openio_keystone_nodes_group in groups -%}
   {{ groups[openio_keystone_nodes_group]
     | map('extract', hostvars, ['openio_bind_address'])
-    | map('regex_replace', '$', ':6019') | join(',') }}
+    | map('regex_replace', '$', ':6019') | list | unique | join(',') }}
   {%- else -%}
   {{ openio_keystone_bind_address }}:6019
   {%- endif %}"


### PR DESCRIPTION
 ##### SUMMARY

If same nodes are referenced many times with different names in the inventory, you have duplicates in the result list

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
Before
```
ok: [server1] =>
  msg: 10.0.2.219:6019,10.0.2.220:6019,10.0.2.217:6019,10.0.2.217:6019,10.0.2.219:6019,10.0.2.220:6019
ok: [server2] =>
  msg: 10.0.2.219:6019,10.0.2.220:6019,10.0.2.217:6019,10.0.2.217:6019,10.0.2.219:6019,10.0.2.220:6019
ok: [server3] =>
  msg: 10.0.2.219:6019,10.0.2.220:6019,10.0.2.217:6019,10.0.2.217:6019,10.0.2.219:6019,10.0.2.220:6019
ok: [server3bis] =>
  msg: 10.0.2.219:6019,10.0.2.220:6019,10.0.2.217:6019,10.0.2.217:6019,10.0.2.219:6019,10.0.2.220:6019
ok: [server1bis] =>
  msg: 10.0.2.219:6019,10.0.2.220:6019,10.0.2.217:6019,10.0.2.217:6019,10.0.2.219:6019,10.0.2.220:6019
ok: [server2bis] =>
  msg: 10.0.2.219:6019,10.0.2.220:6019,10.0.2.217:6019,10.0.2.217:6019,10.0.2.219:6019,10.0.2.220:6019
```

After:
```
ok: [server1] =>
  msg: 10.0.2.219:6019,10.0.2.220:6019,10.0.2.217:6019
ok: [server3] =>
  msg: 10.0.2.219:6019,10.0.2.220:6019,10.0.2.217:6019
ok: [server2] =>
  msg: 10.0.2.219:6019,10.0.2.220:6019,10.0.2.217:6019
ok: [server3bis] =>
  msg: 10.0.2.219:6019,10.0.2.220:6019,10.0.2.217:6019
ok: [server2bis] =>
  msg: 10.0.2.219:6019,10.0.2.220:6019,10.0.2.217:6019
ok: [server1bis] =>
  msg: 10.0.2.219:6019,10.0.2.220:6019,10.0.2.217:6019
```