### PR TITLE
BUGFIX/MINOR(keystone): Exit wsgi process when app fails to load

### DIFF
--- a/templates/keystone-uwsgi.ini.j2
+++ b/templates/keystone-uwsgi.ini.j2
@@ -7,6 +7,7 @@ wsgi-file = {{ openio_keystone_bindir }}/{{ item }}
 http-socket = {{ openio_keystone_uwsgi_bind[item]['http-socket']|default('') }}
 plugins = python
 
+need-app = true
 master = true
 enable-threads = true
 processes = {{ openio_keystone_wsgi_processes }}


### PR DESCRIPTION
 ##### SUMMARY

Previously, when keystone wsgi app couldn't load (e.g. if the
configuration was incorrect), the wsgi process would switch to full
dynamic mode, and thus stay up (at least as seen by gridinit). This
makes sure the process exits if keystone app can't be loaded.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION