### PR TITLE
FEATURE(keystone): Add logfile for uwsgi

### DIFF
--- a/templates/keystone-uwsgi.ini.j2
+++ b/templates/keystone-uwsgi.ini.j2
@@ -5,7 +5,7 @@ gid = {{ openio_keystone_system_group_name }}
 
 wsgi-file = {{ openio_keystone_bindir }}/{{ item }}
 http-socket = {{ openio_keystone_uwsgi_bind[item]['http-socket']|default('') }}
-plugins = python
+plugins = python,logfile
 
 need-app = true
 master = true
@@ -18,3 +18,5 @@ lazy-apps = true
 add-header = Connection: close
 buffer-size = 65535
 thunder-lock = true
+req-logger = file:/var/log/keystone/uswgi-req-{{ item }}.log
+log-format = %(ltime) %(addr) %(proto) %(method) %(uri) %(status) %(size) %(micros)

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -5,6 +5,7 @@ keystone_packages:
   - openstack-keystone
   - uwsgi
   - uwsgi-plugin-python2
+  - uwsgi-logger-file
   - python2-shade
   - rsync
   - python-openstackclient


### PR DESCRIPTION
 ##### SUMMARY

For many reasons, it may be interesting to trace these requests.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
example on xenial
```ini
[uwsgi]
uid = keystone
gid = keystone

wsgi-file = /usr/bin/keystone-wsgi-public
http-socket = 172.17.0.3:5000
plugins = python,logfile

need-app = true
master = true
enable-threads = true
processes = 8
threads = 1
exit-on-reload = true
die-on-term = true
lazy-apps = true
add-header = Connection: close
buffer-size = 65535
thunder-lock = true
req-logger = file:/var/log/keystone/uswgi-req-keystone-wsgi-public.log
log-format = %(ltime) %(addr) %(proto) %(method) %(uri) %(status) %(size) %(micros)
```